### PR TITLE
Feat/add file of application.yml

### DIFF
--- a/src/main/java/com/getIt/global/resources/application/application.yml
+++ b/src/main/java/com/getIt/global/resources/application/application.yml
@@ -1,0 +1,16 @@
+spring:
+  datasource:
+    url: jdbc:mysql://localhost:3306/getit_db?useSSL=false&allowPublicKeyRetrieval=true&characterEncoding=UTF-8&serverTimezone=Asia/Seoul
+    username: root
+    password: 1234
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    database: mysql
+    database-platform: org.hibernate.dialect.MySQL8Dialect
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        format_sql: true
+        show_sql: true


### PR DESCRIPTION
# Feat #5 : add file of application.yml

- 데이터베이스를 넣고 연동하려면 application.yml 파일을 작업해야함.
- 도커에 local database를 올려서 당장 임시로 작업하기 위함.