### PR TITLE
feat #6 : add the file of Cors (for attaching)

### DIFF
--- a/src/main/java/com/getIt/global/config/CorsConfig.java
+++ b/src/main/java/com/getIt/global/config/CorsConfig.java
@@ -1,0 +1,15 @@
+package com.getit.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfig implements WebMvcConfigurer {
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("http://localhost:5173")
+                .allowedMethods("GET", "POST", "PUT", "DELETE");
+    }
+}


### PR DESCRIPTION
# Feat 6 : add the file of cors

## Contents
- 프론트엔드와 연결을 위해서 cors 파일을 생성해줌.
- 현재 기본 값이 localhost에 해당 port number로 지정되어있음
- 차후 vercell 사용 등으로 변경될 경우를 변경 필요.